### PR TITLE
Adding project map badge to README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,7 @@ To report bugs, request features, or receive assistance, please https://github.c
 image:https://github.com/{project-owner}/{project-name}/actions/workflows/early-access.yml/badge.svg["Build Status", link="https://github.com/{project-owner}/{project-name}/actions/workflows/early-access.yml"]
 image:https://img.shields.io/github/release/{project-owner}/{project-name}.svg["Latest", link="https://github.com/{project-owner}/{project-name}/releases/latest"]
 image:https://codecov.io/gh/{project-owner}/{project-name}/branch/master/graph/badge.svg?token=LDK7BAJLJI["Coverage", link="https://codecov.io/gh/{project-owner}/{project-name}"]
+image:https://sourcespy.com/shield.svg["Project Map", link="https://sourcespy.com/github/redisdeveloperriot/"]
 
 == License
 


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/redisdeveloperriot/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.