### PR TITLE
Include cycloneDx for creation of an SBOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'org.cyclonedx.bom' version '1.8.2'
+}
+
 config {
     info {
         description = 'RIOT'
@@ -41,7 +45,7 @@ config {
         implementation {
             enabled = true
         }
-        
+
         people {
             person {
                 id    = 'jruaux'
@@ -58,7 +62,7 @@ config {
             }
         }
     }
-    
+
     licensing {
         enabled = false
         licenses {
@@ -93,7 +97,7 @@ allprojects {
 
 subprojects { subproj ->
     if (!subproj.name.contains('guide')) {
-    
+
         config {
 	        info {
 	            description = project.project_description
@@ -126,7 +130,7 @@ subprojects { subproj ->
 	    configurations {
 	        all*.exclude module: 'spring-boot-starter-logging'
 	    }
-	    
+
 	    bootJar {
             enabled = false
         }
@@ -152,4 +156,8 @@ subprojects { p ->
 
 boolean hasTestsAt(File testDir) {
     testDir.exists() && testDir.listFiles()?.size()
+}
+
+cyclonedxBom {
+    skipProjects = ["guide"]
 }


### PR DESCRIPTION
This PR adds the CycloneDX plugin for SBOM creation.  The output BOM can then be scanned with a tool like `trivy` to identify dependencies that will show up in vulnerability scans.

```bash
./gradlew cyclonedxBom
# Trivy example
trivy sbom build/reports/bom.json
# osv-scanner example
osv-scanner --sbom=build/reports/bom.json
```

Output of osv-scanner for main branch looks like the following:
```
osv-scanner --sbom=build/reports/bom.json
Scanned /Users/bcorecol/workspace/riot/build/reports/bom.json as CycloneDX SBOM and found 157 packages
╭─────────────────────────────────────┬──────┬───────────┬─────────────────────────────────────────────┬──────────────┬────────────────────────╮
│ OSV URL                             │ CVSS │ ECOSYSTEM │ PACKAGE                                     │ VERSION      │ SOURCE                 │
├─────────────────────────────────────┼──────┼───────────┼─────────────────────────────────────────────┼──────────────┼────────────────────────┤
│ https://osv.dev/GHSA-c28r-hw5m-5gv3 │ 7.9  │ Maven     │ com.amazonaws:aws-java-sdk-s3               │ 1.11.792     │ build/reports/bom.json │
│ https://osv.dev/GHSA-xh97-72ww-2w58 │ 7.3  │ Maven     │ com.google.oauth-client:google-oauth-client │ 1.31.2       │ build/reports/bom.json │
│ https://osv.dev/GHSA-4265-ccf5-phj5 │ 7.5  │ Maven     │ org.apache.commons:commons-compress         │ 1.24.0       │ build/reports/bom.json │
│ https://osv.dev/GHSA-4g9r-vxhx-9pgx │ 8.1  │ Maven     │ org.apache.commons:commons-compress         │ 1.24.0       │ build/reports/bom.json │
│ https://osv.dev/GHSA-4gg5-vx3j-xwc7 │ 7.5  │ Maven     │ com.google.protobuf:protobuf-java           │ 3.14.0       │ build/reports/bom.json │
│ https://osv.dev/GHSA-77rm-9x9h-xj3g │ 7.5  │ Maven     │ com.google.protobuf:protobuf-java           │ 3.14.0       │ build/reports/bom.json │
│ https://osv.dev/GHSA-g5ww-5jh7-63cx │ 7.5  │ Maven     │ com.google.protobuf:protobuf-java           │ 3.14.0       │ build/reports/bom.json │
│ https://osv.dev/GHSA-h4h5-3hr4-j3g2 │ 5.7  │ Maven     │ com.google.protobuf:protobuf-java           │ 3.14.0       │ build/reports/bom.json │
│ https://osv.dev/GHSA-wrvw-hg22-4m67 │ 7.5  │ Maven     │ com.google.protobuf:protobuf-java           │ 3.14.0       │ build/reports/bom.json │
│ https://osv.dev/GHSA-5mg8-w23w-74h3 │ 3.3  │ Maven     │ com.google.guava:guava                      │ 30.0-android │ build/reports/bom.json │
│ https://osv.dev/GHSA-7g45-4rm6-3mm3 │ 5.5  │ Maven     │ com.google.guava:guava                      │ 30.0-android │ build/reports/bom.json │
╰─────────────────────────────────────┴──────┴───────────┴─────────────────────────────────────────────┴──────────────┴────────────────────────╯
```

The AWS item is a simple fix (coming shortly), commons-compress is part of the test dependencies, and the rest are from the Spring GCP library.

